### PR TITLE
Add typeahead search for repos

### DIFF
--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -90,6 +90,11 @@ const Settings = React.createClass({
       gitHubRepo,
       gitHubRepos
     } = this.state;
+    const styles = {
+      repo: {
+        cursor: 'pointer'
+      }
+    };
     return (
       <div>
         <h1>Pivotal Swimlanes Settings</h1>
@@ -125,7 +130,10 @@ const Settings = React.createClass({
               <p><strong>Selected: {this.state.gitHubUser}/{this.state.gitHubRepo}</strong></p>
               <ul>
                 {_.map(gitHubRepos, (repo, i) =>
-                  <li key={i} onClick={() => this.setState({ gitHubUser: repo.owner.login, gitHubRepo: repo.name }) }>
+                  <li
+                    key={i}
+                    style={styles.repo}
+                    onClick={() => this.setState({ gitHubUser: repo.owner.login, gitHubRepo: repo.name }) }>
                     {repo.full_name}
                   </li>
                 )}

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import history from '../history'
 import $ from 'jquery';
+import _ from 'underscore';
 
 const Settings = React.createClass({
   getInitialState() {
@@ -10,8 +11,7 @@ const Settings = React.createClass({
       gitHubToken: '',
       gitHubUser: '',
       gitHubRepo: '',
-      gitHubRepos: '',
-      fetchingData: false
+      gitHubRepos: ''
     };
   },
 
@@ -29,25 +29,34 @@ const Settings = React.createClass({
       gitHubToken,
       gitHubUser,
       gitHubRepo
-    },
-      () => {
-        if (!_.isEmpty(gitHubToken)) {
-          this._fetchRepos();
-        }
-      }
-    );
+    });
   },
 
-  _fetchRepos() {
-    this.setState({ fetchingData: true });
-    // TODO: I think this only returns the first 30 repos
+  _searchRepo(e) {
+    let query = e.target.value;
+    if (query.length === 0) {
+      this.setState({ gitHubRepos: [] });
+      return
+    };
+
+    const [user, repo] = query.split('/')
+
+    let url = ''
+    url += 'https://api.github.com/search/repositories'
+    url += '?'
+    url += $.param({
+      access_token: this.state.gitHubToken,
+      q: repo || query
+    });
+    if (repo) { url += `+user:${user}` }
+
     $.ajax({
-      url: `https://api.github.com/user/repos?sort=pushed&access_token=${this.state.gitHubToken}`,
+      url: url,
       method: 'GET'
     }).done(data =>
-      this.setState({ gitHubRepos: data })
-    ).always(() =>
-      this.setState({ fetchingData: false })
+      this.setState({ gitHubRepos: data.items })
+    ).fail(data =>
+      this.setState({ gitHubRepos: [] })
     );
   },
 
@@ -79,12 +88,8 @@ const Settings = React.createClass({
       gitHubToken,
       gitHubUser,
       gitHubRepo,
-      gitHubRepos,
-      fetchingData
+      gitHubRepos
     } = this.state;
-    if (fetchingData) {
-      return <div>Loading...</div>;
-    }
     return (
       <div>
         <h1>Pivotal Swimlanes Settings</h1>
@@ -113,19 +118,18 @@ const Settings = React.createClass({
             </a>
           ) : (
             <div>
-              <select>
+              <input
+                type='text'
+                placeholder='Search Repos'
+                onChange={_.debounce(this._searchRepo, 500)} />
+              <p><strong>Selected: {this.state.gitHubUser}/{this.state.gitHubRepo}</strong></p>
+              <ul>
                 {_.map(gitHubRepos, (repo, i) =>
-                  <option
-                    key={i}
-                    value={repo.full_name}
-                    selected={repo.full_name === `${gitHubUser}/${gitHubRepo}`}
-                    onChange={() =>
-                      this.setState({ gitHubUser: repo.full_name.split('/')[0], gitHubRepo: repo.name })
-                    }>
-                      {repo.full_name}
-                  </option>
+                  <li key={i} onClick={() => this.setState({ gitHubUser: repo.owner.login, gitHubRepo: repo.name }) }>
+                    {repo.full_name}
+                  </li>
                 )}
-              </select>
+              </ul>
               <br />
             </div>
           )}


### PR DESCRIPTION
Fixes #55 

May want a more robust solution, but this allows quick searching and limiting by user, ie. `mojotech/pivotal` == `q=pivotal+user:mojotech`