### PR TITLE
collect all project data in ProjectContainer and show review stories properly

### DIFF
--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -5,18 +5,17 @@ import _ from 'lodash';
 const Board = React.createClass({
   propTypes: {
     projectName: React.PropTypes.string.isRequired,
-    stories: React.PropTypes.array.isRequired,
-    pullRequests: React.PropTypes.array.isRequired
+    entries: React.PropTypes.array.isRequired
   },
 
   render() {
-    const { stories, pullRequests } = this.props;
-    const unstartedEntries = _.filter(stories, story => story.current_state === 'unstarted' || story.current_state === 'planned')
-    const inProgressEntries = _.filter(stories, story => story.current_state === 'started' || story.current_state === 'rejected')
-    const readyForReviewEntries = pullRequests;
-    const mergedEntries = _.filter(stories, story => story.current_state === 'finished')
-    const deliveredEntries = _.filter(stories, story => story.current_state === 'delivered')
-    const acceptedEntries = _.filter(stories, story => story.current_state === 'accepted')
+    const { entries } = this.props;
+    const unstartedEntries = _.filter(entries, entry => entry.state === 'Unstarted');
+    const inProgressEntries = _.filter(entries, entry => entry.state === 'In Progress');
+    const readyForReviewEntries = _.filter(entries, entry => entry.state === 'Ready for Review');
+    const mergedEntries = _.filter(entries, entry => entry.state === 'Merged');
+    const deliveredEntries = _.filter(entries, entry => entry.state === 'Delivered');
+    const acceptedEntries = _.filter(entries, entry => entry.state === 'Accepted');
     const styles = {
       board: {
         overflow: 'scroll',

--- a/src/components/Entry.js
+++ b/src/components/Entry.js
@@ -6,10 +6,12 @@ const Entry = React.createClass({
   propTypes: {
     entry: React.PropTypes.shape({
       title: React.PropTypes.string.isRequired,
-      url: React.PropTypes.string.isRequired,
-      authors: React.PropTypes.string.isRequired,
-      type: React.PropTypes.oneOf(['feature', 'bug', 'chore', 'pr']),
-      estimate: React.PropTypes.number.isRequired
+      owners: React.PropTypes.arrayOf(React.PropTypes.string),
+      estimate: React.PropTypes.number,
+      reviewUrl: React.PropTypes.string,
+      trackerUrl: React.PropTypes.string,
+      type: React.PropTypes.string.isRequired,
+      state: React.PropTypes.string.isRequired
     }).isRequired
   },
 
@@ -22,22 +24,38 @@ const Entry = React.createClass({
         paddingTop: 3,
         paddingBottom: 3
       },
-      authors: { fontSize: 10 },
+      owners: { fontSize: 10 },
       estimate: { paddingLeft: 5 },
-      link: { float: 'right' }
+      links: { float: 'right' },
+      link: { paddingLeft: 4 }
     };
-    const { title, url, authors, type, estimate } = this.props.entry;
+    const {
+      title,
+      owners,
+      estimate,
+      reviewUrl,
+      trackerUrl,
+      type,
+      state
+    } = this.props.entry;
     return (
       <Paper style={styles.content}>
         <div>
           {_.isEmpty(type) ? null : <img src={require(`../img/${type}.png`)} alt={type} />}
-          <span style={styles.estimate}>{Array(estimate + 1).join('•')}</span>
-          <a href={url} target='_new'>
-            <img src={require('../img/open_in_new.png')} style={styles.link} />
-          </a>
+          {estimate ? <span style={styles.estimate}>{Array(estimate + 1).join('•')}</span> : null}
+          <div style={styles.links}>
+            {state === 'Ready for Review' ? (
+              <a href={reviewUrl} target='_new' style={styles.link}>
+                <img src={require('../img/pr.png')} />
+              </a>
+            ) : null}
+            <a href={trackerUrl} target='_new' style={styles.link}>
+              <img src={require('../img/open_in_new.png')} />
+            </a>
+          </div>
         </div>
         <div style={styles.title}>{title}</div>
-        <div style={styles.authors}>{authors}</div>
+        <div style={styles.owners}>{owners.join(', ')}</div>
       </Paper>
     );
   }

--- a/src/components/Project.js
+++ b/src/components/Project.js
@@ -1,116 +1,23 @@
 import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
-import $ from 'jquery';
 import _ from 'underscore';
 import HeaderBar from './HeaderBar';
 import Board from './Board';
 import { CircularProgress } from 'material-ui';
 
-const pivotalAPI = 'https://www.pivotaltracker.com/services/v5';
-
 const Project = React.createClass({
   propTypes: {
-    pivotalToken: PropTypes.string.isRequired,
-    pivotalProjectId: PropTypes.string.isRequired,
-    gitHubToken: PropTypes.string.isRequired,
-    gitHubRepo: PropTypes.string.isRequired
-  },
-
-  getInitialState() {
-    return { stories: null, pullRequests: null, projectName: null };
-  },
-
-  componentDidMount() {
-    this._fetchProjectName();
-    this._fetchStories();
-    this._fetchPullRequests();
-  },
-
-  _fetchProjectName() {
-    let { pivotalProjectId, pivotalToken } = this.props;
-    $.ajax({
-      url: `${pivotalAPI}/projects/${pivotalProjectId}`,
-      method: 'GET',
-      beforeSend: xhr => xhr.setRequestHeader('X-TrackerToken', pivotalToken)
-    }).done(data =>
-      this.setState({ projectName: data.name })
-    ).fail(() =>
-      this.setState({ errorFetchingData: true })
-    );
-  },
-
-  _fetchStories() {
-    let { pivotalProjectId, pivotalToken } = this.props;
-    this._fetchProjectMembers()
-    .then(members => {
-      this._members = members;
-      return $.ajax({
-        url: `${pivotalAPI}/projects/${pivotalProjectId}/iterations?scope=current`,
-        method: 'GET',
-        beforeSend: xhr => xhr.setRequestHeader('X-TrackerToken', pivotalToken)
-      });
-    }).done(data => {
-      let storiesData = _.select(data[0].stories, story => story.story_type !== 'release');
-      let ownerIds = _.chain(storiesData).map(story => story.owner_ids).flatten().unique().value();
-      let stories = _(storiesData)
-        .map(story => {
-          return {
-            title: story.name,
-            url: story.url,
-            authors: story.owner_ids.map(id => this._mapOwnerIdToName(id)).join(', '),
-            type: story.story_type,
-            estimate: story.estimate || 0,
-            current_state: story.current_state
-          };
-        });
-      this.setState({ stories: stories });
-    }).fail(() =>
-      this.setState({ errorFetchingData: true })
-    );
-  },
-
-  _fetchPullRequests() {
-    let { gitHubToken, gitHubRepo } = this.props;
-    $.ajax({
-      url: `https://api.github.com/repos/${gitHubRepo}/pulls?state=open&access_token=${gitHubToken}`,
-      method: 'GET'
-    }).done(data => {
-      this.setState({
-        pullRequests: _.map(data, pullRequest => {
-          return {
-            title: pullRequest.title,
-            url: pullRequest.html_url,
-            authors: pullRequest.user.login,
-            estimate: 0,
-            type: 'pr'
-          };
-        })
-      })
-    }
-    ).fail(() =>
-      this.setState({ errorFetchingData: true })
-    );
-  },
-
-  _fetchProjectMembers() {
-    let { pivotalProjectId, pivotalToken } = this.props;
-    return $.ajax({
-      url: `${pivotalAPI}/projects/${pivotalProjectId}/memberships`,
-      method: 'GET',
-      beforeSend: xhr => xhr.setRequestHeader('X-TrackerToken', pivotalToken)
-    });
-  },
-
-  _mapOwnerIdToName(id) {
-    return _.first(_.filter(this._members, member => member.person.id === id)).person.name;
+    projectName: React.PropTypes.string,
+    entries: React.PropTypes.array,
+    error: React.PropTypes.bool.isRequired
   },
 
   render() {
     let styles = {
       centered: { textAlign: 'center' }
     };
-    let { stories, pullRequests, projectName, errorFetchingData } = this.state;
-    let loading = (!errorFetchingData && (_.isNull(stories) || _.isNull(pullRequests) || _.isNull(projectName)));
+    let { projectName, entries, error } = this.props;
+    let loading = (_.isEmpty(projectName) || _.isEmpty(entries)) && !error;
     return (
       <div>
         {loading ? (
@@ -118,7 +25,7 @@ const Project = React.createClass({
             <CircularProgress mode='indeterminate' />
           </div>
         ) : (
-          errorFetchingData ? (
+          error ? (
             <div>
               <p>Error fetching data.</p>
               <Link to='settings'>Configure Settings</Link>
@@ -126,7 +33,7 @@ const Project = React.createClass({
           ) : (
             <div>
               <HeaderBar projectName={projectName} />
-              <Board projectName={projectName} stories={stories} pullRequests={pullRequests} />
+              <Board projectName={projectName} entries={entries} />
             </div>
           )
         )}

--- a/src/components/SwimLane.js
+++ b/src/components/SwimLane.js
@@ -5,15 +5,7 @@ import _ from 'lodash';
 const SwimLane = React.createClass({
   propTypes: {
     title: React.PropTypes.string.isRequired,
-    entries: React.PropTypes.arrayOf(
-      React.PropTypes.shape({
-        title: React.PropTypes.string.isRequired,
-        url: React.PropTypes.string.isRequired,
-        authors: React.PropTypes.string.isRequired,
-        type: React.PropTypes.oneOf(['feature', 'bug', 'chore', 'pr']),
-        estimate: React.PropTypes.number.isRequired
-      }).isRequired
-    ).isRequired
+    entries: React.PropTypes.array.isRequired
   },
 
   render() {


### PR DESCRIPTION
Finishes #6 and half of #51 

All data needed to render Project.js and its nested components is collected in ProjectContainer.js and the projectName and an array of entries are passed to Project.js as props. Real nice because now all Project.js expects is a list of entries, doesn't know anything about how they're made up of pull requests/stories/etc. This data is also collected without storing stories/PRs/etc. in state, just chains ajax calls and produces a final list of entries.

Also updated to show stories w/ PRs open in the Ready for Review column only, with a link to the PR. Before we had the story in In Progress and another entry for the pull request in Ready for Review.