### PR TITLE
Remove repo if not authorized

### DIFF
--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -46,7 +46,7 @@ const Settings = ({
 
   const removeGitHubAccount = e => {
     e.preventDefault();
-    onSettingsChange({ gitHubAuthorized: false });
+    onSettingsChange({ gitHubAuthorized: false, selectedRepo: null });
   };
 
   const repoChangeHandler = _.debounce(onRepoQueryChange, 500);


### PR DESCRIPTION
Sets the repo to null when removing GitHub account authorization.
Fixes #86 